### PR TITLE
hotfix(ratiocolors): Silence console.log ratio

### DIFF
--- a/private/scripts/dynamicTable.js
+++ b/private/scripts/dynamicTable.js
@@ -1111,7 +1111,8 @@ window.qBittorrent.DynamicTable = (function() {
             this.columns['ratio'].updateTd = function(td, row) {
                 const ratio = this.getRowValue(row);
                 const string = (ratio === -1) ? '∞' : window.qBittorrent.Misc.toFixedPointString(ratio, 2);
-                console.log(parseFloat(ratio));
+                
+                // console.log(parseFloat(ratio));
 
                 switch (true) {
                     case (ratio < 0.5):


### PR DESCRIPTION
It's noisy in the console to have continuous logs. Let's quiet this down.